### PR TITLE
Updated Easing library to support elm-core 0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 2.0.1
+* Updated to 0.16
+
 ### 2.0.0
 * Remove `friction`, `gravity`
 

--- a/Easing.elm
+++ b/Easing.elm
@@ -304,14 +304,14 @@ easeOutBounce time =
         t3 = time - (2.25 / 2.75)
         t4 = time - (2.65 / 2.75)
     in
-        if | time < 1 / 2.75 ->
-                a * time * time
-           | time < 2 / 2.75 ->
-                a * t2 * t2 + 0.75
-           | time < 2.5 / 2.75 ->
-                a * t3 * t3 + 0.9375
-           | otherwise ->
-                a * t4 * t4 + 0.984375
+        if time < 1 / 2.75 then
+            a * time * time
+        else if time < 2 / 2.75 then
+            a * t2 * t2 + 0.75
+        else if time < 2.5 / 2.75 then
+            a * t3 * t3 + 0.9375
+        else
+            a * t4 * t4 + 0.984375
 
 {-|-}
 easeInOutBounce : Easing

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "2.0.1",
     "summary": "Creating animations and transitions with easing functions.",
     "repository": "https://github.com/Dandandan/Easing.git",
     "license": "BSD3",
@@ -10,7 +10,7 @@
         "Easing"
     ],
     "dependencies": {
-        "elm-lang/core": "2.1.0 <= v < 3.0.0"
+        "elm-lang/core": "2.1.0 <= v < 4.0.0"
     },
-    "elm-version": "0.15.1 <= v < 0.16.0"
+    "elm-version": "0.15.1 <= v < 0.17.0"
 }


### PR DESCRIPTION
Minor edits required for Easing to support elm-core 0.16 (to support removal of if patterns and adjusting constraints in elm-package.json). I wasn't sure if "2.0.1" should be a good revision update, but these changes are fully compatible with 2.0.0, so it makes some sense.