### PR TITLE
Update for 0.17

### DIFF
--- a/Easing.elm
+++ b/Easing.elm
@@ -1,4 +1,4 @@
-module Easing (ease,
+module Easing exposing (ease,
  Interpolation, Animation,
  float, point2d, point3d, color, pair,
  cycle, invert, retour, inOut, flip,
@@ -15,7 +15,7 @@ module Easing (ease,
  easeInBack, easeOutBack, easeInOutBack,
  easeInBounce, easeOutBounce, easeInOutBounce,
  easeInElastic, easeOutElastic, easeInOutElastic
- ) where
+ )
 
 {-| `Easing` is a library for working creating simple animations with easing functions. Easing functions interpolate a value over time. This can be a value of any type, including numbers, points and colors.
 

--- a/elm-package.json
+++ b/elm-package.json
@@ -10,7 +10,7 @@
         "Easing"
     ],
     "dependencies": {
-        "elm-lang/core": "2.1.0 <= v < 4.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0"
     },
-    "elm-version": "0.15.1 <= v < 0.17.0"
+    "elm-version": "0.17.0 <= v < 0.18.0"
 }


### PR DESCRIPTION
This is a mechanical and non-invasive update for 0.17, which introduced a new syntax for declaring modules. This means the code will not be backwards compatible and therefore the lower version bounds must be bumped to 0.17 and core/4.0.0.